### PR TITLE
Drop whitelisting functionality for GIDs

### DIFF
--- a/shinigami/cli.py
+++ b/shinigami/cli.py
@@ -106,7 +106,6 @@ class Application:
                     node,
                     ssh_limit,
                     self._settings.uid_whitelist,
-                    self._settings.gid_whitelist,
                     timeout=self._settings.ssh_timeout,
                     debug=self._settings.debug)
                 for node in nodes

--- a/shinigami/settings.py
+++ b/shinigami/settings.py
@@ -23,11 +23,6 @@ class Settings(BaseSettings):
         default=(0,),
         description='Do not terminate processes launched by users with the given UID values.')
 
-    gid_whitelist: Tuple[Union[int, Tuple[int, int]]] = Field(
-        title='Whitelisted Group IDs',
-        default=(0,),
-        description='Do not terminate processes launched by users with the given GID values.')
-
     clusters: Tuple[str, ...] = Field(
         title='Clusters to Scan',
         default=tuple(),

--- a/tests/settings/test_settings.py
+++ b/tests/settings/test_settings.py
@@ -27,8 +27,3 @@ class Defaults(TestCase):
         """Test the UID whitelist includes UID 0"""
 
         self.assertIn(0, Settings().uid_whitelist)
-
-    def test_gid_ignores_root(self) -> None:
-        """Test the GID whitelist includes GID 0"""
-
-        self.assertIn(0, Settings().gid_whitelist)


### PR DESCRIPTION
The current GID whitelisting implementation only considers a user's primary GID. This doesn't match the desired functionality outlined in #48. 

Support for GID whitelisting is being dropped until it can be correctly implemented.