### PR TITLE
Terminate orphaned processes matching blacklisted user IDs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,10 +25,11 @@ classifiers = [
 shinigami = "shinigami.cli:Application.execute"
 
 [tool.poetry.dependencies]
-python = ">=3.8"
+python = ">=3.9"
 pydantic = "^2.0.3"
 pydantic-settings = "^2.0.2"
 asyncssh = {extras = ["bcrypt", "fido2"], version = "^2.13.2"}
+pandas = "^2.1.0"
 
 [tool.poetry.group.tests]
 optional = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,11 +25,11 @@ classifiers = [
 shinigami = "shinigami.cli:Application.execute"
 
 [tool.poetry.dependencies]
-python = ">=3.9"
+python = ">=3.8"
 pydantic = "^2.0.3"
 pydantic-settings = "^2.0.2"
 asyncssh = {extras = ["bcrypt", "fido2"], version = "^2.13.2"}
-pandas = "^2.1.0"
+pandas = "1.5.3"
 
 [tool.poetry.group.tests]
 optional = true

--- a/shinigami/cli.py
+++ b/shinigami/cli.py
@@ -99,10 +99,9 @@ class Application:
             nodes = utils.get_nodes(cluster, self._settings.ignore_nodes)
             coroutines = [
                 utils.terminate_errant_processes(
-                    cluster,
-                    node,
-                    ssh_limit,
-                    self._settings.uid_whitelist,
+                    node=node,
+                    ssh_limit=ssh_limit,
+                    uid_blacklist=self._settings.uid_blacklist,
                     timeout=self._settings.ssh_timeout,
                     debug=self._settings.debug)
                 for node in nodes

--- a/shinigami/settings.py
+++ b/shinigami/settings.py
@@ -20,10 +20,10 @@ class Settings(BaseSettings):
         default=False,
         description='When enabled, processes are scanned and logged but not terminated.')
 
-    uid_whitelist: Tuple[Union[int, Tuple[int, int]]] = Field(
-        title='Whitelisted User IDs',
+    uid_blacklist: Tuple[Union[int, Tuple[int, int]]] = Field(
+        title='Blacklisted User IDs',
         default=(0,),
-        description='Do not terminate processes launched by users with the given UID values.')
+        description='Only terminate processes launched by users with the given UID values.')
 
     clusters: Tuple[str, ...] = Field(
         title='Clusters to Scan',

--- a/shinigami/utils.py
+++ b/shinigami/utils.py
@@ -93,5 +93,5 @@ async def terminate_errant_processes(
             return
 
         proc_id_str = ' '.join(terminate.PGID)
-        logging.info(f"[{node}] Sending termination signal for processes {proc_id_str}")
+        logging.info(f"[{node}] Sending termination signal for process groups {proc_id_str}")
         await conn.run(f"pkill --signal -9 --pgroup {proc_id_str}", check=True)

--- a/shinigami/utils.py
+++ b/shinigami/utils.py
@@ -79,7 +79,7 @@ async def terminate_errant_processes(
     async with ssh_limit, asyncssh.connect(node, options=ssh_options) as conn:
 
         logging.info(f'[{node}] Scanning for processes')
-        ps_data = conn.run('ps -eo pid,ppid,uid,cmd', check=True)
+        ps_data = conn.run('ps -eo pid,pgid,uid,cmd', check=True)
         process_df = pd.read_fwf(StringIO(ps_data), usecols=[0, 1, 2, 3])
 
         # Identify orphaned processes and filter them by the UID blacklist
@@ -91,6 +91,6 @@ async def terminate_errant_processes(
         if debug:
             return
 
-        proc_id_str = ' '.join(terminate.PID)
+        proc_id_str = ' '.join(terminate.PGID)
         logging.info(f"[{node}] Sending termination signal for processes {proc_id_str}")
-        await conn.run(f"kill -9 {proc_id_str}", check=True)
+        await conn.run(f"pkill --signal -9 --pgroup {proc_id_str}", check=True)

--- a/shinigami/utils.py
+++ b/shinigami/utils.py
@@ -78,9 +78,10 @@ async def terminate_errant_processes(
     logging.debug(f'Waiting to connect to {node}')
     async with ssh_limit, asyncssh.connect(node, options=ssh_options) as conn:
 
+        # Fetch running process data from the remote machine
         logging.info(f'[{node}] Scanning for processes')
-        ps_data = conn.run('ps -eo pid,pgid,uid,cmd', check=True)
-        process_df = pd.read_fwf(StringIO(ps_data), usecols=[0, 1, 2, 3])
+        ps_data = await conn.run('ps -eo pid,pgid,uid', check=True)
+        process_df = pd.read_fwf(StringIO(ps_data.stdout))
 
         # Identify orphaned processes and filter them by the UID blacklist
         orphaned = process_df[process_df.PPID == 1]

--- a/tests/settings/test_settings.py
+++ b/tests/settings/test_settings.py
@@ -22,8 +22,3 @@ class Defaults(TestCase):
         """Test the ``ignore_nodes`` setting is empty"""
 
         self.assertEqual(tuple(), Settings().ignore_nodes)
-
-    def test_uid_ignores_root(self) -> None:
-        """Test the UID whitelist includes UID 0"""
-
-        self.assertIn(0, Settings().uid_whitelist)

--- a/tests/utils/test_id_in_whitelist.py
+++ b/tests/utils/test_id_in_whitelist.py
@@ -2,7 +2,7 @@
 
 from unittest import TestCase
 
-from shinigami.utils import id_in_whitelist
+from shinigami.utils import id_in_blacklist
 
 
 class Whitelisting(TestCase):
@@ -11,19 +11,19 @@ class Whitelisting(TestCase):
     def test_empty_whitelist(self) -> None:
         """Test the return value is ``False`` for all ID values when the whitelist is empty"""
 
-        self.assertFalse(id_in_whitelist(0, []))
-        self.assertFalse(id_in_whitelist(123, []))
+        self.assertFalse(id_in_blacklist(0, []))
+        self.assertFalse(id_in_blacklist(123, []))
 
     def test_whitelisted_by_id(self) -> None:
         """Test return values for a whitelist of explicit ID values"""
 
         whitelist = (123, 456, 789)
-        self.assertTrue(id_in_whitelist(456, whitelist))
-        self.assertFalse(id_in_whitelist(0, whitelist))
+        self.assertTrue(id_in_blacklist(456, whitelist))
+        self.assertFalse(id_in_blacklist(0, whitelist))
 
     def test_whitelisted_by_id_range(self) -> None:
         """Test return values for a whitelist of ID ranges"""
 
         whitelist = (0, 1, 2, (100, 300))
-        self.assertTrue(id_in_whitelist(123, whitelist))
-        self.assertFalse(id_in_whitelist(301, whitelist))
+        self.assertTrue(id_in_blacklist(123, whitelist))
+        self.assertFalse(id_in_blacklist(301, whitelist))


### PR DESCRIPTION
Closes #47
Closes #48 as no longer relevant 
Closes #52

This PR revises the process termination logic to kill all orphaned processes belonging to users in a predefined blacklist.