### PR TITLE
Fix bug in parsing of ps output

### DIFF
--- a/shinigami/utils.py
+++ b/shinigami/utils.py
@@ -86,8 +86,6 @@ async def terminate_errant_processes(
         # Identify orphaned processes and filter them by the UID blacklist
         orphaned = process_df[process_df.PPID == 1]
         terminate = orphaned[orphaned['UID'].apply(id_in_blacklist, blacklist=uid_blacklist)]
-        with open('/home/djperrefort/Github/pitt-crc/shinigami/ps.txt', 'w') as out:
-            out.write(ps_data.stdout)
 
         for _, row in terminate.iterrows():
             logging.debug(f'[{node}] Marking for termination {dict(row)}')


### PR DESCRIPTION
closes #70 

It looks like the `fwf` parser wasn't guessing the column widths correctly. I tried increasing the number of rows it uses in it's guess, but the results were mixed. Using the CSV parser with a `\s+` delimiter seems stable. However, we will need an alternative whenever we address #69 since the commands will include whitespace characters.