### PR TITLE
Updates CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,17 @@ updates:
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 100
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 100
+    groups:
+      actions-dependencies:
+        patterns:
+          - "*"

--- a/.github/workflows/CodeQL.yml
+++ b/.github/workflows/CodeQL.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [ main ]
   schedule:
-    - cron: 0 0 1 * *
+    - cron: 0 7 1 * *
 
 jobs:
   analyze:
@@ -23,20 +23,18 @@ jobs:
         language: [ python ]
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
-      with:
-        languages: ${{ matrix.language }}
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: ${{ matrix.language }}
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
-      with:
-        category: /language:${{matrix.language}}
-
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2
+        with:
+          category: /language:${{matrix.language}}
 
   # Use this job for branch protection rules
   report-codeql-status:

--- a/.github/workflows/PackagePublish.yml
+++ b/.github/workflows/PackagePublish.yml
@@ -31,6 +31,9 @@ jobs:
             environment: publish-pypi
 
     steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -41,15 +44,12 @@ jobs:
         with:
           virtualenvs-create: false
 
-      - name: Checkout source
-        uses: actions/checkout@v4
-
       # Get the new package version from the release tag
-      # Release tags are expected to start with "refs/tags/v", so the first 11 characters are stripped
+      # Git release tags are expected to start with "refs/tags/v"
       - name: Set package version
         run: |
           release_tag=${{github.ref}}
-          poetry version "${release_tag:11}"
+          poetry version "${release_tag#refs/tags/v}"
 
       - name: Build package
         run: poetry build -v
@@ -57,7 +57,7 @@ jobs:
       - name: Publish package
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          verbose: true
+          print-hash: true
           repository-url: ${{ matrix.host }}
           user: ${{ secrets.REPO_USER }}
           password: ${{ secrets.REPO_PASSWORD }}

--- a/.github/workflows/PackageTest.yml
+++ b/.github/workflows/PackageTest.yml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch:
   workflow_call:
   push:
+  schedule:
+    - cron: 0 7 1,15 * *
 
 jobs:
   run-tests:
@@ -23,17 +25,17 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install poetry
-        run: |
-          pip install poetry
-          poetry env use python${{ matrix.python-version }}
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: false
 
       - name: Install dependencies
         run: poetry install --with tests
 
       - name: Run tests with coverage
         run: |
-          poetry run coverage run -m unittest discover tests
+          poetry run coverage run -m unittest discover 
           poetry run coverage report --omit="tests/*"
           poetry run coverage xml --omit="tests/*" -o coverage.xml
 


### PR DESCRIPTION
This PR is part of a general update designed to standardize and improve CI across the GitHub organization. Changes include:

   - Monthly CodeQL scans are now run at 7 AM
   - Tests are now run twice a month
   - Python dependencies are grouped into a single update
   - Poetry is installed using a dedicated action
