### PR TITLE
Fixes bug where slurm users are terminated

### DIFF
--- a/shinigami/utils.py
+++ b/shinigami/utils.py
@@ -143,9 +143,11 @@ async def terminate_errant_processes(
         process_df = await get_remote_processes(conn)
 
         # Filter process data by various whitelist/blacklist criteria
+        # Outputs from each filter function call are passed to the next filter
+        # so the order of the function calls matter significantly
+        process_df = exclude_active_slurm_users(process_df)
         process_df = include_orphaned_processes(process_df)
         process_df = include_user_whitelist(process_df, uid_whitelist)
-        process_df = exclude_active_slurm_users(process_df)
 
         for _, row in process_df.iterrows():  # pragma: nocover
             logging.info(f'[{node}] Marking for termination {dict(row)}')


### PR DESCRIPTION
The ordering of the filtering functions introduced a bug where the process data used to identify Slurm users was filtered out by previous filter functions. This PR fixes the issue by updating the order of operations.  

A more robust fix is to combine the results of each filter function at the end instead of chaining them one after another. After talking offline, it's been decided to implement such a fix in the future if it becomes necessary (or as more time becomes availible).
